### PR TITLE
Added support to initialize multiple consumers for same bus instance.

### DIFF
--- a/MetroBus.ConsumerSample.Contracts/FooCreatedEvent.cs
+++ b/MetroBus.ConsumerSample.Contracts/FooCreatedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace MetroBus.ConsumerSample.Contracts
+{
+    public class FooCreatedEvent : IFooCreatedEvent
+    {
+        public int Id { get; set; }
+    }
+}

--- a/MetroBus.ConsumerSample.Contracts/MetroBus.ConsumerSample.Contracts.csproj
+++ b/MetroBus.ConsumerSample.Contracts/MetroBus.ConsumerSample.Contracts.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CreateFooRequest.cs" />
+    <Compile Include="FooCreatedEvent.cs" />
     <Compile Include="ICreateFooResponse.cs" />
     <Compile Include="ICreateFooRequest.cs" />
     <Compile Include="IFooCreatedEvent.cs" />

--- a/MetroBus.ConsumerSample/App.config
+++ b/MetroBus.ConsumerSample/App.config
@@ -7,7 +7,6 @@
     <add key="RabbitMqUri" value="rabbitmq://localhost/" />
     <add key="RabbitMqUserName" value="guest" />
     <add key="RabbitMqPassword" value="guest" />
-    <add key="FooQueue" value="foo" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/MetroBus.ConsumerSample/FirstFooCreatedEventConsumer.cs
+++ b/MetroBus.ConsumerSample/FirstFooCreatedEventConsumer.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using MassTransit;
+using MetroBus.ConsumerSample.Contracts;
+
+namespace MetroBus.ConsumerSample
+{
+    public class FirstFooCreatedEventConsumer : IConsumer<IFooCreatedEvent>
+    {
+        public async Task Consume(ConsumeContext<IFooCreatedEvent> context)
+        {
+            await Console.Out.WriteLineAsync($"First consumer says: Foo:{context.Message.Id} created.");
+        }
+    }
+}

--- a/MetroBus.ConsumerSample/FooCommandConsumerService.cs
+++ b/MetroBus.ConsumerSample/FooCommandConsumerService.cs
@@ -1,34 +1,38 @@
 ﻿using System.Configuration;
 using MassTransit;
+using MetroBus.ConsumerSample.Contracts;
 
 namespace MetroBus.ConsumerSample
 {
     //You can use this class with TopShelf as a windows service.
     public class FooCommandConsumerService
     {
-        private IBusControl _consumerBusControl;
-        private string _rabbitMqUri;
-        private string _rabbitMqUserName;
-        private string _rabbitMqPassword;
-        private string _queueName;
+        private readonly IBusControl _consumerBusControl;
 
         public FooCommandConsumerService()
         {
-            _rabbitMqUri = ConfigurationManager.AppSettings["RabbitMqUri"];
-            _rabbitMqUserName = ConfigurationManager.AppSettings["RabbitMqUserName"];
-            _rabbitMqPassword = ConfigurationManager.AppSettings["RabbitMqPassword"];
-            _queueName = ConfigurationManager.AppSettings["FooQueue"];
+            var rabbitMqUri = ConfigurationManager.AppSettings["RabbitMqUri"];
+            var rabbitMqUserName = ConfigurationManager.AppSettings["RabbitMqUserName"];
+            var rabbitMqPassword = ConfigurationManager.AppSettings["RabbitMqPassword"];
 
-            _consumerBusControl = MetroBusInitializer.Instance.UseRabbitMq(_rabbitMqUri, _rabbitMqUserName, _rabbitMqPassword)
-                             .InitializeConsumer<FooCommandConsumer>(_queueName).Build();
+            _consumerBusControl = MetroBusInitializer.Instance
+                                    .UseRabbitMq(rabbitMqUri, rabbitMqUserName, rabbitMqPassword)
+                                    .RegisterConsumer<FooCommandConsumer>("foo.create-queue")
+                                    .RegisterConsumer<FirstFooCreatedEventConsumer>("foo-created.first-action-queue")
+                                    .RegisterConsumer<SecondFooCreatedEventConsumer>("foo-created.second-action-queue")
+                                    .Build();
         }
 
-        public void Start()
+        public async void Start()
         {
+            await _consumerBusControl.Publish<IFooCreatedEvent>(new FooCreatedEvent
+            {
+                Id = 5
+            });
             _consumerBusControl.Start();
         }
 
-        public void Stop()
+        public async void Stop()
         {
             _consumerBusControl.Stop();
         }

--- a/MetroBus.ConsumerSample/MetroBus.ConsumerSample.csproj
+++ b/MetroBus.ConsumerSample/MetroBus.ConsumerSample.csproj
@@ -68,10 +68,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FirstFooCreatedEventConsumer.cs" />
     <Compile Include="FooCommandConsumer.cs" />
     <Compile Include="FooCommandConsumerService.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SecondFooCreatedEventConsumer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/MetroBus.ConsumerSample/SecondFooCreatedEventConsumer.cs
+++ b/MetroBus.ConsumerSample/SecondFooCreatedEventConsumer.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using MassTransit;
+using MetroBus.ConsumerSample.Contracts;
+
+namespace MetroBus.ConsumerSample
+{
+    public class SecondFooCreatedEventConsumer : IConsumer<IFooCreatedEvent>
+    {
+        public async Task Consume(ConsumeContext<IFooCreatedEvent> context)
+        {
+            throw new Exception("Whoaaa...... Booom...");
+            await Console.Out.WriteLineAsync($"Second consumer says: Foo:{context.Message.Id} created.");
+        }
+    }
+}

--- a/MetroBus/Properties/AssemblyInfo.cs
+++ b/MetroBus/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Lightweight messaging wrapper of _MassTransit_
 PM> Install-Package MetroBus 
 ```
 
-####Features:
-- Currently only support RabbitMQ transport
-- Provide easily create **Producer** and **Consumer** for Pub/Sub
-- Provide easily  **Request/Response** conversation
-- Include incremental auto retry policy
-- Include circuit breaker
-- Include rate limiter
+#### Features:
+- Currently only supports RabbitMQ transport
+- Provides easy way to create **Producer** and **Consumer** for Pub/Sub
+- Provides easy way to handle **Request/Response** conversations
+- Includes optional incremental auto retry policy
+- Includes optional circuit breaker
+- Includes optional rate limiter
 
 Usage:
 -----


### PR DESCRIPTION
In some scenarios we need to initialize multiple consumer on same process.
So I added support for initialization process by chaging code inside InitializeConsumer method and renaming it to RegisterConsumer. Since there are breaking changes I incremented version to 2.