### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/MetroBus.Autofac/MetroBus.Autofac.csproj
+++ b/src/MetroBus.Autofac/MetroBus.Autofac.csproj
@@ -12,7 +12,15 @@
     <Copyright>Copyright 2018 Gökhan Gökalp</Copyright>
     <PackageTags>MassTransit, RabbitMQ, Messaging, Publish Subscribe, Request/Response, Autofac</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/GokGokalp/MetroBus/master/misc/metrobus-logo.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="MassTransit.Autofac" Version="5.1.5" />

--- a/src/MetroBus.Core/MetroBus.Core.csproj
+++ b/src/MetroBus.Core/MetroBus.Core.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2018 Gökhan Gökalp</Copyright>
     <PackageTags>MassTransit, RabbitMQ, Messaging, Publish Subscribe, Request/Response</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/GokGokalp/MetroBus/master/misc/metrobus-logo.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="5.1.5" />

--- a/src/MetroBus.Microsoft.Extensions.DependencyInjection/MetroBus.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/MetroBus.Microsoft.Extensions.DependencyInjection/MetroBus.Microsoft.Extensions.DependencyInjection.csproj
@@ -12,7 +12,15 @@
     <Copyright>Copyright 2018 Gökhan Gökalp</Copyright>
     <PackageTags>MassTransit, RabbitMQ, Messaging, Publish Subscribe, Request/Response, Microsoft.Extensions.DependencyInjection</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/GokGokalp/MetroBus/master/misc/metrobus-logo.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="MassTransit.Extensions.DependencyInjection" Version="5.1.5" />

--- a/src/MetroBus/MetroBus.csproj
+++ b/src/MetroBus/MetroBus.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2018 Gökhan Gökalp</Copyright>
     <PackageTags>MassTransit, RabbitMQ, Messaging, Publish Subscribe, Request/Response</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/GokGokalp/MetroBus/master/misc/metrobus-logo.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="5.1.5" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
